### PR TITLE
dunfell-record: Pass --compatible=3.0 to stap

### DIFF
--- a/record/dunfell-record.in
+++ b/record/dunfell-record.in
@@ -50,4 +50,4 @@ fi
 
 # Run the stap script.
 echo "$0: Logging to ‘$log_file’ for command ‘$*’." >&2
-exec stap --unprivileged --dyninst --download-debuginfo=yes --ldd -o "$log_file" -c "$*" $STAP_OPTIONS @datadir@/libdunfell-@DFL_API_VERSION@/dunfell-record.stp
+exec stap --compatible=3.0 --unprivileged --dyninst --download-debuginfo=yes --ldd -o "$log_file" -c "$*" $STAP_OPTIONS @datadir@/libdunfell-@DFL_API_VERSION@/dunfell-record.stp


### PR DESCRIPTION
user_string2 used in glib's .stp file is only available for versions <
3.0, excerpt from systemtaps uconversions.stp:
```
%(systemtap_v <= "3.0" %?
function user_string2:string (addr:long, err_msg:string) {
	return user_string_n(addr, @MAXSTRINGLEN, err_msg)
}
%)
```
So pass --compatible=3.0 to the stap invocation to make sure we have
access to these.